### PR TITLE
Support using ES modules to define scenarios

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -2,7 +2,7 @@
 
 import yargs from 'yargs';
 
-yargs
+yargs(process.argv.slice(2))
   .demandCommand(1, 'Use one of the above commands')
   .command(
     'list',
@@ -22,7 +22,7 @@ yargs
         .array('require')
         .option('matrix', { type: 'string' }),
     async argv => {
-      let mod = await import('./list');
+      let mod = await import('./list.js');
       await mod.printList(argv);
     }
   )
@@ -53,7 +53,7 @@ yargs
         })
         .array('require'),
     async argv => {
-      let mod = await import('./output');
+      let mod = await import('./output.js');
       await mod.output(argv);
     }
   )

--- a/list.ts
+++ b/list.ts
@@ -1,7 +1,12 @@
-import { Scenario, seenScenarios } from '.';
-import { sync as globSync } from 'glob';
+import { Scenario, seenScenarios } from './index.js';
+import glob from 'glob';
 import { resolve } from 'path';
 import { format } from 'util';
+
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
+const { sync: globSync } = glob;
 
 export interface ListParams {
   files: string[];
@@ -12,12 +17,12 @@ export interface ListParams {
 export async function list(params: ListParams): Promise<Scenario[]> {
   if (params.require) {
     for (let r of params.require) {
-      require(require.resolve(r, { paths: [process.cwd()]}));
+      await import(require.resolve(r, { paths: [process.cwd()]}));
     }
   }
   for (let pattern of params.files) {
     for (let file of globSync(pattern)) {
-      require(resolve(file));
+      await import(resolve(file));
     }
   }
   return seenScenarios;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "scenario-tester": "./cli.js"
   },
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "prepare": "tsc",
     "start": "tsc --watch",

--- a/test.ts
+++ b/test.ts
@@ -1,24 +1,24 @@
 import { Project } from 'fixturify-project';
-import { Scenarios } from './index';
+import { Scenarios } from './index.js';
 import type { PreparedApp } from './index';
-import Qunit = require('qunit');
-import child_process = require('child_process');
+import Qunit from 'qunit';
+import child_process from 'child_process';
 
 function hello1(project: Project) {
   project.linkDependency('hello', {
-    baseDir: __dirname + '/fixtures',
+    baseDir: './fixtures',
     resolveName: 'hello1',
   });
 }
 
 function hello2(project: Project) {
   project.linkDependency('hello', {
-    baseDir: __dirname + '/fixtures',
+    baseDir: './fixtures',
     resolveName: 'hello',
   });
 }
 
-const scenarios = Scenarios.fromDir(__dirname + '/fixtures/app').expand({
+const scenarios = Scenarios.fromDir('./fixtures/app').expand({
   hello1,
   hello2,
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2019",
-    "module": "commonjs",
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
     "declaration": true,
     "esModuleInterop": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
While working on #10 I was testing out setting up scenario-tester in a non-built package (ember-cli-fastboot) and I wasn't able to get `scenario-tester list` to work because the code expected commonJS. 

I couldn't see any way around this other than to make sure that typescript outputs modules (so we can do dynamic imports properly) but then this means you can only use scenario-tester in an ESM environment. I've added tests to show specifics of ESM and CommonJS environments.

I'm wondering if we should just move everything to ESM or if we should do something like https://thesametech.com/how-to-build-typescript-project/ to allow us to build an ESM and CommonJS compatible output. Thoughts? 

Edit: here is a PR to ember-cli-fastboot that implements scenario-tester using this PR 👍  https://github.com/ember-fastboot/ember-cli-fastboot/pull/919