### PR TITLE
fix types discovery for node10 projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,13 @@
   "resolutions": {
     "type-fest": "^3.0.0"
   },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*"
+      ]
+    }
+  },
   "dependencies": {
     "fixturify-project": "^6.0.0",
     "fs-extra": "^9.1.0",

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,6 +1,6 @@
 import { Project } from 'fixturify-project';
-import { Scenarios } from '../';
-import type { PreparedApp } from '../';
+import { Scenarios } from '../dist/';
+import type { PreparedApp } from '../dist/';
 import Qunit from 'qunit';
 import execa from 'execa';
 


### PR DESCRIPTION
We discovered in https://github.com/embroider-build/embroider/pull/1714 that the types weren't being discovered in projects that are relying on node10 moduleResolution. @SergeAstapov came to our rescue and suggested this change 🎉 