### PR TITLE
fix docs build

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -29,7 +29,7 @@ jobs:
         run: pnpm install
 
       - name: Build documentation
-        run: pnpm docs
+        run: pnpm run docs
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Apparently there is a built-in command `pnpm docs` so CI was trying to run that 🤦 

updated CI to build using `pnpm run docs` 👍 